### PR TITLE
Add: Filter by Category

### DIFF
--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -9,25 +9,24 @@
 
 module Types
   class QueryType < Types::BaseObject
-
-    field :get_users, [Types::UserType], null: false, description: "Returns a list of users"
+    field :get_users, [Types::UserType], null: false, description: 'Returns a list of users'
     def get_users
       User.all
     end
 
-    field :get_a_user, Types::UserType, null: false, description: "Returns a user" do
+    field :get_a_user, Types::UserType, null: false, description: 'Returns a user' do
       argument :id, ID, required: true
     end
     def get_a_user(id:)
       User.find(id)
     end
 
-    field :get_items, [Types::ItemType], null: false, description: "Returns all items"
+    field :get_items, [Types::ItemType], null: false, description: 'Returns all items'
     def get_items
       Item.all
     end
 
-    field :get_user_items, [Types::ItemType], null: false, description: "Returns a users items" do
+    field :get_user_items, [Types::ItemType], null: false, description: 'Returns a users items' do
       argument :id, ID, required: true
     end
     def get_user_items(id:)
@@ -35,11 +34,19 @@ module Types
       @user.items
     end
 
-    field :item_search, [Types::ItemType], null: false, description: "Returns an array of items with a similar name" do
+    field :item_search, [Types::ItemType], null: false, description: 'Returns an array of items with a similar name' do
       argument :keyword, String, required: true
     end
     def item_search(keyword:)
-      items = Item.where("name ILIKE ?", "%#{keyword}%")
+      items = Item.where('name ILIKE ?', "%#{keyword}%")
+    end
+
+    field :filter_by_category, [Types::ItemType], null: false,
+                                                  description: 'Returns an array of items with same category' do
+      argument :keyword, String, required: true
+    end
+    def filter_by_category(keyword:)
+      items = Item.where(category: keyword)
     end
   end
 end


### PR DESCRIPTION
## What was changed:
Adds a filter by category option to the graphql queries

## Explain the reason for changes: (If there is no spec file how were things tested)
Previously there was no way to return items of the same category. Now there is.