### PR TITLE
Items mutations

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,9 +95,13 @@ GEM
     matrix (0.4.2)
     method_source (1.0.0)
     mini_mime (1.1.2)
+    mini_portile2 (2.8.0)
     minitest (5.16.2)
     msgpack (1.5.3)
     nio4r (2.5.8)
+    nokogiri (1.13.7)
+      mini_portile2 (~> 2.8.0)
+      racc (~> 1.4)
     nokogiri (1.13.7-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.13.7-x86_64-linux)
@@ -191,6 +195,7 @@ GEM
       nokogiri (~> 1.8)
 
 PLATFORMS
+  ruby
   x86_64-darwin-21
   x86_64-linux
 

--- a/app/graphql/mutations/create_item.rb
+++ b/app/graphql/mutations/create_item.rb
@@ -1,0 +1,17 @@
+module Mutations
+  class CreateItem < BaseMutation
+    argument :name, String, required: false
+    argument :category, Integer, required: false
+    argument :description, String, required: false
+    argument :available, Boolean, required: false
+    argument :amount, Integer, required: false
+    argument :status, Integer, required: false
+    argument :user_id, ID, required: false
+    field :item, Types::ItemType, null: false
+
+    def resolve(**args)
+      new_item = Item.create!(args)
+      { item: new_item }
+    end
+  end
+end

--- a/app/graphql/mutations/create_item.rb
+++ b/app/graphql/mutations/create_item.rb
@@ -8,6 +8,7 @@ module Mutations
     argument :status, Integer, required: false
     argument :user_id, ID, required: false
     field :item, Types::ItemType, null: false
+    field :user, Types::UserType, null: false
 
     def resolve(**args)
       new_item = Item.create!(args)

--- a/app/graphql/mutations/delete_item.rb
+++ b/app/graphql/mutations/delete_item.rb
@@ -1,0 +1,15 @@
+module Mutations
+  class DeleteItem < BaseMutation
+    argument :id, ID, required: true
+    field :success, Boolean
+
+    def resolve(id:)
+      item = Item.find(id)
+      if item.destroy
+        { success: true }
+      else
+        { success: false }
+      end
+    end
+  end
+end

--- a/app/graphql/mutations/edit_item.rb
+++ b/app/graphql/mutations/edit_item.rb
@@ -1,0 +1,19 @@
+module Mutations
+  class EditItem < BaseMutation
+    argument :id, ID, required: true
+    argument :name, String, required: false
+    argument :category, Integer, required: false
+    argument :description, String, required: false
+    argument :available, Boolean, required: false
+    argument :amount, Integer, required: false
+    argument :status, Integer, required: false
+    argument :user_id, ID, required: false
+    field :item, Types::ItemType, null: false
+
+    def resolve(id:, **args)
+      updated_item = Item.find(id)
+      updated_item.update(args)
+      { item: updated_item } if updated_item.save
+    end
+  end
+end

--- a/app/graphql/types/item_type.rb
+++ b/app/graphql/types/item_type.rb
@@ -9,7 +9,7 @@ module Types
     field :available, Boolean, null: false
     field :amount, Integer, null: false
     field :status, String, null: false
-    field :user_id, Integer, null: false
+    field :user_id, ID, null: false
     field :created_at, GraphQL::Types::ISO8601DateTime, null: false
     field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
   end

--- a/app/graphql/types/item_type.rb
+++ b/app/graphql/types/item_type.rb
@@ -9,7 +9,7 @@ module Types
     field :available, Boolean, null: false
     field :amount, Integer, null: false
     field :status, String, null: false
-    field :user_id, ID, null: false
+    field :user, Types::UserType, null: false
     field :created_at, GraphQL::Types::ISO8601DateTime, null: false
     field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
   end

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -1,13 +1,13 @@
 module Types
   class MutationType < Types::BaseObject
+    # user mutations
     field :create_user, mutation: Mutations::CreateUser
     field :delete_user, mutation: Mutations::DeleteUser
     field :edit_user, mutation: Mutations::EditUser
-    # # TODO: remove me
-    # field :user_field, Object, null: false,
-    #   description: "All users"
-    # def user_field
-    #   User.all
-    # end
+
+    # item mutations
+    field :create_item, mutation: Mutations::CreateItem
+    # field :delete_item, mutation: Mutations::DeleteItem
+    # field :edit_item, mutation: Mutations::EditItem
   end
 end

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -8,6 +8,6 @@ module Types
     # item mutations
     field :create_item, mutation: Mutations::CreateItem
     field :edit_item, mutation: Mutations::EditItem
-    # field :delete_item, mutation: Mutations::DeleteItem
+    field :delete_item, mutation: Mutations::DeleteItem
   end
 end

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -7,7 +7,7 @@ module Types
 
     # item mutations
     field :create_item, mutation: Mutations::CreateItem
+    field :edit_item, mutation: Mutations::EditItem
     # field :delete_item, mutation: Mutations::DeleteItem
-    # field :edit_item, mutation: Mutations::EditItem
   end
 end

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,0 +1,21 @@
+## What was changed:
+Feat:
+- `mutation_type.rb`
+  - `#create_item field`
+  - `#edit_item field`
+  - `#delete_item field`<br>
+
+Refactor:
+- `item_type.rb`
+- `getItems_request_spec.rb`
+
+Test:
+- `createItem_request_spec.rb`
+
+## Explain the reason for changes: (If there is no spec file how were things tested)
+Front End requested for `User name` to show up along with any item query.
+
+Visually tested the other mutation requests but writing spec tests for the rest of the `Item Mutations` after this PR
+
+
+## Link to issue: (Delete if no issue)

--- a/spec/requests/getItems_request_spec.rb
+++ b/spec/requests/getItems_request_spec.rb
@@ -50,6 +50,10 @@ RSpec.describe 'getItems', type: :request do
             available
             category
             status
+            user {
+              id
+              name
+            }
           }
         }
       GQL

--- a/spec/requests/mutations/createItem_request_spec.rb
+++ b/spec/requests/mutations/createItem_request_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+
+RSpec.describe 'createItem', type: :request do
+  it 'creates a item' do
+    @bojack = User.create!(name: 'Bojack Horseman', email: 'bjackhman@email.com')
+    create_item_mutation =
+      <<~GQL
+        mutation createItem {
+            createItem(
+              input: {
+                userId: "#{@bojack.id}"
+                name: "Magical Chisels",
+                category: 7,
+                description: "They're magical!",
+                available: true,
+                amount: 9,
+                status: 0
+                }) {
+              item {
+                id
+                name
+                category
+                description
+                available
+                amount
+                status
+                user {
+                  id
+                  name
+                }
+              }
+            }
+          }
+      GQL
+    post '/graphql', params: { query: create_item_mutation }
+    json = JSON.parse(response.body, symbolize_names: true)
+    data = json[:data][:createItem][:item]
+
+    expect(Item.last.id.to_s).to eq(data[:id])
+    expect(Item.last.name).to eq('Magical Chisels')
+    expect(Item.last.category).to eq('Wood Working')
+    expect(Item.last.available).to eq(true)
+    expect(Item.last.amount).to eq(9)
+    expect(Item.last.status).to eq('Give')
+    expect(Item.last.user.id).to eq(@bojack.id)
+    expect(Item.last.user.name).to eq('Bojack Horseman')
+  end
+end


### PR DESCRIPTION
## What was changed:
Feat:
- `mutation_type.rb`
  - `#create_item field`
  - `#edit_item field`
  - `#delete_item field`<br>

Refactor:
- `item_type.rb`
- `getItems_request_spec.rb`

Test:
- `createItem_request_spec.rb`

## Explain the reason for changes: (If there is no spec file how were things tested)
Front End requested for `User name` to show up along with any item query.

Visually tested the other mutation requests but writing spec tests for the rest of the `Item Mutations` after this PR. Will have better PR conventions in the future to reduce amount of files in a single PR.