### PR TITLE
Refactor: deleteItem + editItem Spec Files

### DIFF
--- a/spec/requests/mutations/deleteItem_request_spec.rb
+++ b/spec/requests/mutations/deleteItem_request_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'createItem', type: :request do
       name: 'Purple Yarn',
       category: 0,
       description: '.8 gauge purple yarn, 1 bundle',
-      available: true,
+      available: 0,
       amount: 1,
       status: 0
     )

--- a/spec/requests/mutations/editItem_request_spec.rb
+++ b/spec/requests/mutations/editItem_request_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'editItem', type: :request do
       name: 'Purple Yarn',
       category: 0,
       description: '.8 gauge purple yarn, 1 bundle',
-      available: true,
+      available: 0,
       amount: 1,
       status: 0
     )
@@ -21,7 +21,7 @@ RSpec.describe 'editItem', type: :request do
                 name: "Magical Yarn",
                 category: 0,
                 description: "They're magical!",
-                available: true,
+                available: 0,
                 amount: 3,
                 status: 1
                 }) {


### PR DESCRIPTION
Ensuring conventions stay consistent with the :avaliable attribute change from boolean to enum status

## What was changed:
Refactor:
- `deleteItems_request_spec.rb`
- `editItems_request_spec.rb`


## Explain the reason for changes: (If there is no spec file how were things tested)
Quick Fix

## Link to issue: (Delete if no issue)