### PR TITLE
Bcrypt setup

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem 'puma', '~> 3.11'
 # Use Redis adapter to run Action Cable in production
 # gem 'redis', '~> 4.0'
 # Use ActiveModel has_secure_password
-# gem 'bcrypt', '~> 3.1.7'
+gem 'bcrypt', '~> 3.1.7'
 
 # Use ActiveStorage variant
 # gem 'mini_magick', '~> 4.8'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,6 +45,7 @@ GEM
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     arel (9.0.0)
+    bcrypt (3.1.18)
     bootsnap (1.12.0)
       msgpack (~> 1.2)
     builder (3.2.4)
@@ -95,9 +96,13 @@ GEM
     matrix (0.4.2)
     method_source (1.0.0)
     mini_mime (1.1.2)
+    mini_portile2 (2.8.0)
     minitest (5.16.2)
     msgpack (1.5.3)
     nio4r (2.5.8)
+    nokogiri (1.13.7)
+      mini_portile2 (~> 2.8.0)
+      racc (~> 1.4)
     nokogiri (1.13.7-arm64-darwin)
       racc (~> 1.4)
     nokogiri (1.13.7-x86_64-darwin)
@@ -196,11 +201,13 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  ruby
   x86_64-darwin-20
   x86_64-darwin-21
   x86_64-linux
 
 DEPENDENCIES
+  bcrypt (~> 3.1.7)
   bootsnap (>= 1.1.0)
   byebug
   capybara

--- a/app/graphql/mutations/create_user.rb
+++ b/app/graphql/mutations/create_user.rb
@@ -2,12 +2,13 @@ module Mutations
   class CreateUser < BaseMutation
     argument :name, String, required: true
     argument :email, String, required: true
+    argument :password, String, required: true
+    argument :password_confirmation, String, required: true
     field :user, Types::UserType, null: false
 
     def resolve(**args)
       new_user = User.create!(args)
-      {user: new_user}
+      { user: new_user }
     end
   end
-
 end

--- a/app/graphql/mutations/edit_user.rb
+++ b/app/graphql/mutations/edit_user.rb
@@ -8,8 +8,6 @@ module Mutations
 
     def resolve(id:, **args)
       updated_user = User.find(id)
-      # updated_user.update!(args)
-      # updated_user.save
       if updated_user.update(args)
       { user: updated_user }
       else

--- a/app/graphql/mutations/edit_user.rb
+++ b/app/graphql/mutations/edit_user.rb
@@ -8,14 +8,14 @@ module Mutations
 
     def resolve(id:, **args)
       updated_user = User.find(id)
-      updated_user.update(args)
-      updated_user.save
-      # if updated_user.update(args)
+      # updated_user.update!(args)
+      # updated_user.save
+      if updated_user.update(args)
       { user: updated_user }
-      # else
-      #   raise GraphQL::ExecutionError,
-      #         "#{args[:email]} is already associated with another account. Your email must be unique."
-      # end
+      else
+        raise GraphQL::ExecutionError,
+              "#{args[:email]} is already associated with another account. Your email must be unique."
+      end
     end
   end
 end

--- a/app/graphql/mutations/edit_user.rb
+++ b/app/graphql/mutations/edit_user.rb
@@ -3,17 +3,19 @@ module Mutations
     argument :id, ID, required: true
     argument :name, String, required: false
     argument :email, String, required: false
+    argument :password, String, required: false
     field :user, Types::UserType
-    
+
     def resolve(id:, **args)
       updated_user = User.find(id)
-
       updated_user.update(args)
-      if updated_user.save
-        { user: updated_user }
-      else
-        raise GraphQL::ExecutionError.new("#{args[:email]} is already associated with another account. Your email must be unique.")
-      end
+      updated_user.save
+      # if updated_user.update(args)
+      { user: updated_user }
+      # else
+      #   raise GraphQL::ExecutionError,
+      #         "#{args[:email]} is already associated with another account. Your email must be unique."
+      # end
     end
   end
 end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -21,6 +21,20 @@ module Types
       User.where(email: "#{email}").first
     end
 
+    field :login_a_user, Types::UserType, null: false, description: 'Returns a user' do
+      argument :email, String, required: true
+      argument :password, String, required: true
+    end
+    def login_a_user(email:, password:)
+      user = User.where(email: "#{email}").first
+      if user.authenticate(password)
+        user
+      else
+        raise GraphQL::ExecutionError,
+              "Email or password incorrect"
+      end
+    end
+
     field :get_items, [Types::ItemType], null: false, description: 'Returns all items'
     def get_items
       Item.all

--- a/app/graphql/types/user_type.rb
+++ b/app/graphql/types/user_type.rb
@@ -5,6 +5,7 @@ module Types
     field :id, ID, null: false
     field :name, String, null: false
     field :email, String, null: false
+    field :password_digest, String, null: false
     field :items, [Types::ItemType], null: true
     field :created_at, GraphQL::Types::ISO8601DateTime, null: false
     field :updated_at, GraphQL::Types::ISO8601DateTime, null: false

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,7 @@
 class User < ApplicationRecord
   has_many :items, dependent: :destroy
 
-  validates_presence_of :name, :email, :password
+  validates_presence_of :name, :email#, :password
   has_secure_password
 
   validates_uniqueness_of :email

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,8 +1,8 @@
 class User < ApplicationRecord
   has_many :items, dependent: :destroy
 
-  validates_presence_of :name, :email
+  validates_presence_of :name, :email, :password
+  has_secure_password
+
   validates_uniqueness_of :email
-
-
 end

--- a/db/migrate/20220708032148_create_users.rb
+++ b/db/migrate/20220708032148_create_users.rb
@@ -3,6 +3,7 @@ class CreateUsers < ActiveRecord::Migration[5.2]
     create_table :users do |t|
       t.string :name
       t.string :email
+      t.string :password_digest
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -31,6 +31,7 @@ ActiveRecord::Schema.define(version: 2022_07_08_032537) do
   create_table "users", force: :cascade do |t|
     t.string "name"
     t.string "email"
+    t.string "password_digest"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,12 +1,13 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
-  describe "relationships" do
+  describe 'relationships' do
     it { should have_many(:items) }
   end
 
-  describe "validations" do
+  describe 'validations' do
     it { should validate_presence_of(:name) }
+    it { should validate_presence_of(:password) }
     it { should validate_uniqueness_of(:email) }
   end
 end

--- a/spec/requests/getAUser_request_spec.rb
+++ b/spec/requests/getAUser_request_spec.rb
@@ -2,7 +2,8 @@ require 'rails_helper'
 
 RSpec.describe 'getAUser', type: :request do
   before do
-    @bojack = User.create!(name: 'Bojack Horseman', email: 'bjackhman@email.com')
+    @bojack = User.create!(name: 'Bojack Horseman', email: 'bjackhman@email.com', password: 'bjackhman',
+                           password_confirmation: 'bjackhman')
   end
 
   it 'returns a user based on id' do
@@ -19,7 +20,7 @@ RSpec.describe 'getAUser', type: :request do
         }
       GQL
     end
-    
+
     post '/graphql', params: { query: query(email: @bojack.email) }
     json = JSON.parse(response.body, symbolize_names: true)
     data = json[:data][:getAUser]
@@ -28,26 +29,26 @@ RSpec.describe 'getAUser', type: :request do
     expect(data[:email]).to eq @bojack.email
   end
 
-  it "returns an error if not found" do
+  it 'returns an error if not found' do
     def query(email:)
       <<~GQL
-      query {
-        getAUser(
-          email: "#{email}"
-          ) {
-            id
-            name
-            email
+        query {
+          getAUser(
+            email: "#{email}"
+            ) {
+              id
+              name
+              email
+            }
           }
-        }
-        GQL
-      end
+      GQL
+    end
 
-    post '/graphql', params: { query: query(email: "ojac") }
+    post '/graphql', params: { query: query(email: 'ojac') }
     json = JSON.parse(response.body, symbolize_names: true)
-    data = json[:errors][0][:message]   
+    data = json[:errors][0][:message]
 
-    expect(data).to eq("Cannot return null for non-nullable field Query.getAUser")
+    expect(data).to eq('Cannot return null for non-nullable field Query.getAUser')
     expect(data).to_not eq(@bojack.name)
   end
 end

--- a/spec/requests/getItems_request_spec.rb
+++ b/spec/requests/getItems_request_spec.rb
@@ -2,7 +2,8 @@ require 'rails_helper'
 
 RSpec.describe 'getItems', type: :request do
   it 'returns all item instances' do
-    @bojack = User.create!(name: 'Bojack Horseman', email: 'bjackhman@email.com')
+    @bojack = User.create!(name: 'Bojack Horseman', email: 'bjackhman@email.com', password: 'bjackhman',
+                           password_confirmation: 'bjackhman')
 
     yarn = Item.create!(
       name: 'Purple Yarn',

--- a/spec/requests/getUserItems_request_spec.rb
+++ b/spec/requests/getUserItems_request_spec.rb
@@ -2,8 +2,10 @@ require 'rails_helper'
 
 RSpec.describe 'getUserItems', type: :request do
   it 'returns a users items' do
-    susan = User.create!(name: 'Susan', email: 'susan@example.com')
-    joseph = User.create!(name: 'Joseph', email: 'joseph@example.com')
+    susan = User.create!(name: 'Susan', email: 'susan@example.com', password: 'bjackhman',
+                         password_confirmation: 'bjackhman')
+    joseph = User.create!(name: 'Joseph', email: 'joseph@example.com', password: 'bjackhman',
+                          password_confirmation: 'bjackhman')
 
     yarn = susan.items.create!(
       name: 'Purple Yarn',

--- a/spec/requests/getUsers_request_spec.rb
+++ b/spec/requests/getUsers_request_spec.rb
@@ -2,8 +2,10 @@ require 'rails_helper'
 
 RSpec.describe 'getUsers', type: :request do
   it 'returns all users instances' do
-    @bojack = User.create!(name: 'Bojack Horseman', email: 'bjackhman@email.com')
-    @pc = User.create!(name: 'Princess Caroline', email: 'pc@email.com')
+    @bojack = User.create!(name: 'Bojack Horseman', email: 'bjackhman@email.com', password: 'bjackhman',
+                           password_confirmation: 'bjackhman')
+    @pc = User.create!(name: 'Princess Caroline', email: 'pc@email.com', password: 'bjackhman',
+                       password_confirmation: 'bjackhman')
     query =
       <<~GQL
         query {

--- a/spec/requests/loginUser_request_spec.rb
+++ b/spec/requests/loginUser_request_spec.rb
@@ -1,0 +1,55 @@
+require 'rails_helper'
+
+RSpec.describe 'getAUser', type: :request do
+  before do
+    @bojack = User.create!(name: 'Bojack Horseman', email: 'bjackhman@email.com', password: 'bjackhman',
+                           password_confirmation: 'bjackhman')
+  end
+
+  it 'returns a user based on email and password' do
+    def query(email:, password:)
+      <<~GQL
+        query {
+          loginAUser(
+            email: "#{@bojack.email}",
+            password: "bjackhman"
+          ) {
+            id
+            name
+            email
+          }
+        }
+      GQL
+    end
+
+    post '/graphql', params: { query: query(email: @bojack.email, password: 'bjackhman') }
+    json = JSON.parse(response.body, symbolize_names: true)
+    data = json[:data][:loginAUser]
+    expect(data[:name]).to eq @bojack.name
+    expect(data[:email]).to eq @bojack.email
+  end
+
+  it 'returns an error if incorrect password' do
+    def query(email:, password:)
+      <<~GQL
+        query {
+          loginAUser(
+            email: "#{@bojack.email}",
+            password: "incorrect"
+          ) {
+            id
+            name
+            email
+          }
+        }
+      GQL
+    end
+
+    post '/graphql', params: { query: query(email: @bojack.email, password: 'incorrect') }
+    json = JSON.parse(response.body, symbolize_names: true)
+    data = json[:errors][0][:message]
+
+    expect(data).to eq('Email or password incorrect')
+    expect(data).to_not eq(@bojack.name)
+  end
+end

--- a/spec/requests/mutations/createItem_request_spec.rb
+++ b/spec/requests/mutations/createItem_request_spec.rb
@@ -2,7 +2,8 @@ require 'rails_helper'
 
 RSpec.describe 'createItem', type: :request do
   it 'creates a item' do
-    @bojack = User.create!(name: 'Bojack Horseman', email: 'bjackhman@email.com')
+    @bojack = User.create!(name: 'Bojack Horseman', email: 'bjackhman@email.com', password: 'bjackhman',
+                           password_confirmation: 'bjackhman')
     create_item_mutation =
       <<~GQL
         mutation createItem {

--- a/spec/requests/mutations/createUser_request_spec.rb
+++ b/spec/requests/mutations/createUser_request_spec.rb
@@ -1,11 +1,33 @@
 require 'rails_helper'
 
 RSpec.describe 'createUser', type: :request do
-  it "creates a user" do
+  it 'creates a user' do
     creater_mutation =
       <<~GQL
         mutation createUser {
-            createUser(input:{name: "User one", email: "one@email.com"}) {
+            createUser(input:{name: "User one", email: "one@email.com", password: "D", passwordConfirmation: "D"}) {
+              user {
+                name
+                email
+                passwordDigest
+              }
+            }
+          }
+      GQL
+    post '/graphql', params: { query: creater_mutation }
+    json = JSON.parse(response.body, symbolize_names: true)
+    data = json[:data][:createUser][:user]
+    expect(data[:name]).to eq('User one')
+    expect(data[:email]).to eq('one@email.com')
+    expect(User.last.name).to eq('User one')
+    expect(User.last.password_digest.chars.count).to eq(60)
+  end
+
+  it 'errors on mismatched password/confirmation' do
+    creater_mutation =
+      <<~GQL
+        mutation createUser {
+            createUser(input:{name: "User one", email: "one@email.com", password: "we<3joe", passwordConfirmation: "we<3joseph"}) {
               user {
                 name
                 email
@@ -13,11 +35,6 @@ RSpec.describe 'createUser', type: :request do
             }
           }
       GQL
-      post '/graphql', params: { query: creater_mutation }
-      json = JSON.parse(response.body, symbolize_names: true)
-      data = json[:data][:createUser][:user]
-      expect(data[:name]).to eq("User one")
-      expect(data[:email]).to eq("one@email.com")
-      expect(User.last.name).to eq("User one")
+    expect { post '/graphql', params: { query: creater_mutation } }.to raise_error(ActiveRecord::RecordInvalid)
   end
 end

--- a/spec/requests/mutations/deleteItem_request_spec.rb
+++ b/spec/requests/mutations/deleteItem_request_spec.rb
@@ -2,7 +2,8 @@ require 'rails_helper'
 
 RSpec.describe 'createItem', type: :request do
   it 'creates a item' do
-    @bojack = User.create!(name: 'Bojack Horseman', email: 'bjackhman@email.com')
+    @bojack = User.create!(name: 'Bojack Horseman', email: 'bjackhman@email.com', password: 'bjackhman',
+                           password_confirmation: 'bjackhman')
     yarn = @bojack.items.create!(
       name: 'Purple Yarn',
       category: 0,

--- a/spec/requests/mutations/deleteUser_request_spec.rb
+++ b/spec/requests/mutations/deleteUser_request_spec.rb
@@ -1,15 +1,17 @@
 require 'rails_helper'
 
 RSpec.describe 'deleteUser', type: :request do
-  it "creates a user" do
+  it 'creates a user' do
     test_user = User.create!(
       id: 1,
-      name: "User 1",
-      email: "one@email.com"
+      name: 'User 1',
+      email: 'one@email.com',
+      password: 'bjackhman',
+      password_confirmation: 'bjackhman'
     )
 
     expect(test_user).to be_a(User)
-    expect(test_user.name).to eq("User 1")
+    expect(test_user.name).to eq('User 1')
     expect(User.all).to include(test_user)
 
     deleter_mutation =

--- a/spec/requests/mutations/editItem_request_spec.rb
+++ b/spec/requests/mutations/editItem_request_spec.rb
@@ -2,7 +2,8 @@ require 'rails_helper'
 
 RSpec.describe 'editItem', type: :request do
   it 'creates a item' do
-    @bojack = User.create!(name: 'Bojack Horseman', email: 'bjackhman@email.com')
+    @bojack = User.create!(name: 'Bojack Horseman', email: 'bjackhman@email.com', password: 'bjackhman',
+                           password_confirmation: 'bjackhman')
     yarn = @bojack.items.create!(
       name: 'Purple Yarn',
       category: 0,

--- a/spec/requests/mutations/editUser_request_spec.rb
+++ b/spec/requests/mutations/editUser_request_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe 'editUser', type: :request do
-  xit 'edits a user' do
+  it 'edits a user' do
     test_user = User.create!(
       id: 1,
       name: 'User 1',
@@ -15,7 +15,7 @@ RSpec.describe 'editUser', type: :request do
     editer_mutation =
       <<~GQL
         mutation editUser {
-          editUser(input:{id: #{test_user.id}, $name: "Edited user name"}) {
+          editUser(input:{id: #{test_user.id}, name: "Edited user name"}) {
             user {
               name
               email

--- a/spec/requests/mutations/editUser_request_spec.rb
+++ b/spec/requests/mutations/editUser_request_spec.rb
@@ -1,22 +1,57 @@
 require 'rails_helper'
 
 RSpec.describe 'editUser', type: :request do
-  it "edits a user" do
-    User.create!(
+  xit 'edits a user' do
+    test_user = User.create!(
       id: 1,
-      name: "User 1",
-      email: "one@email.com"
+      name: 'User 1',
+      email: 'one@email.com',
+      password: 'bjackhman'
+      # password_confirmation: 'bjackhman'
     )
-
-    test_user = User.last
-
     expect(test_user).to be_a(User)
-    expect(test_user.name).to eq("User 1")
+    expect(test_user.name).to eq('User 1')
 
     editer_mutation =
       <<~GQL
+        mutation editUser {
+          editUser(input:{id: #{test_user.id}, $name: "Edited user name"}) {
+            user {
+              name
+              email
+            }
+          }
+        }
+      GQL
+
+    post '/graphql', params: { query: editer_mutation }
+    json = JSON.parse(response.body, symbolize_names: true)
+    edited_user = User.find(test_user.id)
+    expect(json[:data][:editUser][:user][:name]).to eq('Edited user name')
+    expect(json[:data][:editUser][:user][:email]).to eq('one@email.com')
+
+    expect(edited_user.id).to eq(test_user.id)
+    expect(edited_user.name).to eq('Edited user name')
+    expect(edited_user.email).to eq('one@email.com')
+  end
+
+  it 'returns an error when the updated email is already associated with another account' do
+    user_1 = User.create!(
+      name: 'User 1',
+      email: 'user1@email.com',
+      password: 'bjackhman'
+      # password_confirmation: 'bjackhman'
+    )
+    user_2 = User.create!(
+      name: 'User 2',
+      email: 'user2@email.com',
+      password: 'bjackhman'
+      # password_confirmation: 'bjackhman'
+    )
+    error_mutation =
+      <<~GQL
         mutation createUser {
-            editUser(input:{id: #{test_user.id}, name: "Edited user name"}) {
+            editUser(input:{id: #{user_2.id}, email: "user1@email.com"}) {
               user {
                 name
                 email
@@ -25,46 +60,11 @@ RSpec.describe 'editUser', type: :request do
           }
       GQL
 
-    post '/graphql', params: { query: editer_mutation }
-    json = JSON.parse(response.body, symbolize_names: true)
-    edited_user = User.find(test_user.id)
-
-    expect(json[:data][:editUser][:user][:name]).to eq("Edited user name")
-    expect(json[:data][:editUser][:user][:email]).to eq("one@email.com")
-
-    expect(edited_user.id).to eq(test_user.id)
-    expect(edited_user.name).to eq("Edited user name")
-    expect(edited_user.email).to eq("one@email.com")
-  end
-
-  it "returns an error when the updated email is already associated with another account" do
-    user_1 = User.create!(
-      name: "User 1",
-      email: "user1@email.com"
-    )
-    user_2 = User.create!(
-      name: "User 2",
-      email: "user2@email.com"
-    )
-    error_mutation =
-    <<~GQL
-      mutation createUser {
-          editUser(input:{id: #{user_2.id}, email: "user1@email.com"}) {
-            user {
-              name
-              email
-            }
-          }
-        }
-    GQL
-
     post '/graphql', params: { query: error_mutation }
 
     json = JSON.parse(response.body, symbolize_names: true)
 
     error = json[:errors][0]
-
-
     expect(error[:message]).to eq("#{user_1.email} is already associated with another account. Your email must be unique.")
   end
 end


### PR DESCRIPTION
## What was changed:
Feat:
- `User Create Account`
  - `User creation requires password and password confirmation`
  - `User creation then saves password digest`
  - `Edit user can update the password via this endpoint`
- `User log in`
  - Created a new query called `login_a_user`
  - This works the same way as `get_a_user`, with some exceptions
  - Steps:
    - Finds user via `email` passed in as argument/input (same as `get_a_user`)
    - Authenticates user via `password` also passed in as argument/input (exception/new step)
    - If password is correct, send back user data (same as `get_a_user`, if authorized)
    - If password is incorrect, send back error (exception/new step)

Refactor:
- `User migration`
- `User model (user.rb)`
- `create_user.rb`
- `edit_user.rb`
- `query_type.rb`

Feature/new:
- `#login_a_user in query_type.rb`

Test:
- `createUser_request_spec.rb`
- `editUser_request_spec.rb`
- `loginUser_request_spec.rb`

## Explain the reason for changes: (If there is no spec file how were things tested)
This PR allows FE to build functionality allowing users to create their own accounts, with a username and password. Additionally, FE can now build functionality to allow users to log in with their unique credentials (email, password)
